### PR TITLE
Update deployment workflow to use latest action versions and improve …

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,5 @@
-name: Deploy to 3dime.com/converter
+name: 🚀 Deploy website on push
+
 permissions:
   contents: read
 
@@ -10,31 +11,31 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
-      
+      uses: actions/checkout@v5
+
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '20'
         cache: 'npm'
-        
+
     - name: Install dependencies
       run: npm ci
-      
+
     - name: Build Angular app
       run: npm run build -- --configuration=production --base-href=/converter/
-      
+
     - name: Deploy via FTP
-      uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+      uses: SamKirkland/FTP-Deploy-Action@v4.3.6
       with:
         server: ${{ secrets.FTP_SERVER }}
         username: ${{ secrets.FTP_USERNAME }}
         password: ${{ secrets.FTP_PASSWORD }}
-        local-dir: ./dist/converter-app/browser/
         server-dir: ${{ secrets.FTP_PATH }}
+        local-dir: ./dist/converter-app/browser/
         exclude: |
           **/.git*
           **/.git*/**


### PR DESCRIPTION
This pull request updates the deployment GitHub Actions workflow to use the latest versions of key actions and makes minor improvements for clarity and maintainability.

**Workflow version upgrades:**

* Upgraded `actions/checkout` from v4 to v5 for improved performance and features.
* Upgraded `actions/setup-node` from v4 to v5 to ensure compatibility with the latest Node.js features.
* Upgraded `SamKirkland/FTP-Deploy-Action` from v4.3.5 to v4.3.6 for bug fixes and enhancements.

**Workflow clarity improvements:**

* Updated the workflow name to "🚀 Deploy website on push" for better readability.
* Reordered `local-dir` and `server-dir` in the FTP deploy step for consistency and clarity.