### PR TITLE
Update event handling logic to infer year from image context 

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -44,7 +44,10 @@ export const helloWorld = functions.https.onRequest(async (req, res) => {
         baseText += ` Additional context: ${extraContext}`;
       }
 
-      baseText += '. Return structured json with list of events. Be consistent with all events.';
+      const currentYear = new Date().getFullYear();
+      baseText += `. If a year is explicitly written in the image, use it.
+      If no year is visible, assume all events happen in ${currentYear}.
+      Return structured json with list of events. Be consistent with all events.`;
 
       content.push({ type: 'text', text: baseText });
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -46,8 +46,8 @@ export const helloWorld = functions.https.onRequest(async (req, res) => {
 
       const currentYear = new Date().getFullYear();
       baseText += `. If a year is explicitly written in the image, use it.
-      If no year is visible, assume all events happen in ${currentYear}.
-      Return structured json with list of events. Be consistent with all events.`;
+If no year is visible, assume all events happen in ${currentYear}.
+Return structured json with list of events. Be consistent with all events.`;
 
       content.push({ type: 'text', text: baseText });
 


### PR DESCRIPTION
This pull request updates the instructions for generating event data in the `helloWorld` cloud function. The main improvement is to clarify how the year should be determined for events when processing input images.

**Enhancement to event year handling:**

* Updated the instruction in the `helloWorld` function to specify that if a year is explicitly written in the image, it should be used; otherwise, the current year (as determined at runtime) should be assumed for all events. This provides clearer guidance for event date assignment in the output.