### PR TITLE
Update URLs in meta tags and structured data for improved site consistency

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,24 +9,24 @@
     <meta name="keywords" content="calendar converter, ICS files, OCR, PDF to calendar, image to calendar, event extraction, date detection, calendar generator, file converter" />
     <meta name="author" content="File to Calendar Converter" />
     <meta name="robots" content="index, follow" />
-    
+
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="File to Calendar Converter - Convert Images & PDFs to ICS Calendar Files" />
     <meta property="og:description" content="Convert images and PDF files containing event information into downloadable ICS calendar files. Advanced OCR technology automatically detects dates, times, and event details from your documents." />
-    <meta property="og:url" content="https://converter.example.com" />
+    <meta property="og:url" content="https://3dime.com/converter" />
     <meta property="og:site_name" content="File to Calendar Converter" />
-    
+
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="File to Calendar Converter - Convert Images & PDFs to ICS Calendar Files" />
     <meta name="twitter:description" content="Convert images and PDF files containing event information into downloadable ICS calendar files using advanced OCR technology." />
-    
+
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://converter.example.com" />
-    
+    <link rel="canonical" href="https://3dime.com/converter" />
+
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
-    
+
     <!-- Structured Data -->
     <script type="application/ld+json">
     {
@@ -34,7 +34,7 @@
       "@type": "WebApplication",
       "name": "File to Calendar Converter",
       "description": "Convert images and PDF files containing event information into downloadable ICS calendar files using advanced OCR technology",
-      "url": "https://converter.example.com",
+      "url": "https://3dime.com/converter",
       "applicationCategory": "ProductivityApplication",
       "operatingSystem": "Web Browser",
       "offers": {


### PR DESCRIPTION
This pull request updates the URLs in the `src/index.html` file to reflect the new production domain for the File to Calendar Converter application. All references to the previous domain have been replaced to ensure accurate metadata and canonical links.

**Domain and metadata updates:**

* Updated the `og:url` meta tag to use `https://3dime.com/converter` for correct Open Graph sharing.
* Changed the canonical link to point to `https://3dime.com/converter` for improved SEO and accurate search engine indexing.
* Modified the structured data (`url` field in the JSON-LD script) to reflect the new domain.